### PR TITLE
Add OpenMV Gazebo model

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.dae filter=lfs diff=lfs merge=lfs -text

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ roslaunch openmv_cam openmv_cam.launch
 By default, the node uses the following parameters:
 
 ```sh
-roslaunch openmv_cam openmv_cam.launch device:=/dev/ttyACM0 topic:=/openmv_cam/image_raw compressed:=false
+roslaunch openmv_cam openmv_cam.launch device:=/dev/ttyACM0 topic:=openmv_cam/camera_main/image_raw compressed:=false
 ```
 
 ## License

--- a/launch/openmv_cam_gazebo.launch
+++ b/launch/openmv_cam_gazebo.launch
@@ -1,0 +1,22 @@
+<launch>
+
+    <arg name="gui" default="true"/>
+    <arg name="debug" default="false"/>
+    <arg name="verbose" default="false"/>
+    <arg name="paused" default="false"/>
+
+    <include file="$(find gazebo_ros)/launch/empty_world.launch">
+        <arg name="gui" value="$(arg gui)"/>
+        <arg name="debug" value="$(arg debug)"/>
+        <arg name="verbose" value="$(arg verbose)"/>
+        <arg name="paused" value="$(arg paused)"/>
+    </include>
+
+    <arg name="model_sdf" default="$(find openmv_cam)/models/openmv_cam/model.sdf" />
+    <arg name="model_urdf" default="$(find openmv_cam)/models/openmv_cam/urdf/openmv_cam.xacro" />
+
+    <param name="robot_description" command="$(find xacro)/xacro --inorder $(arg model_urdf)" />
+
+    <node name="spawn_model" pkg="gazebo_ros" type="spawn_model" output="screen" args="-urdf -param robot_description -model openmv_cam" />
+
+</launch>

--- a/models/openmv_cam/meshes/README.md
+++ b/models/openmv_cam/meshes/README.md
@@ -1,0 +1,3 @@
+# OpenMV Cam M7 model
+
+Credit: [https://grabcad.com/library/openmv-cam-m7-1](https://grabcad.com/library/openmv-cam-m7-1)

--- a/models/openmv_cam/meshes/model.dae
+++ b/models/openmv_cam/meshes/model.dae
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d1427be0eb7e16ac2829e67ecbfc2e4d79aef553b46f19e1e3c3a62afe37381
+size 4756723

--- a/models/openmv_cam/model.config
+++ b/models/openmv_cam/model.config
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+
+<model>
+  <name>OpenMV Cam</name>
+  <version>1.0</version>
+  <sdf version="1.5">model.sdf</sdf>
+
+  <author>
+    <name>Fabian Schilling</name>
+    <email>fabian.schilling@me.com</email>
+  </author>
+
+  <description>
+    An OpenMV Cam M7 camera model.
+  </description>
+</model>

--- a/models/openmv_cam/model.sdf
+++ b/models/openmv_cam/model.sdf
@@ -1,0 +1,46 @@
+<?xml version="1.0" ?>
+<sdf version="1.5">
+  <model name="openmv_cam">
+    <pose>0 0 0.05 0 0 0</pose>
+    <link name="link">
+      <collision name="collision">
+        <pose>-0.002 0 -0.013 0 0 0</pose>
+        <geometry>
+          <box>
+            <size>0.035 0.035 0.048</size>
+          </box>
+        </geometry>
+      </collision>
+      <visual name="visual">
+        <pose>0 0 0 0 0 0</pose>
+        <geometry>
+          <mesh>
+            <uri>model://openmv_cam/meshes/model.dae</uri>
+          </mesh>
+        </geometry>
+        <material>
+          <script>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+            <name>Gazebo/DarkGray</name>
+          </script>
+        </material>
+      </visual>
+      <sensor name="camera" type="camera">
+        <camera>
+          <horizontal_fov>1.047</horizontal_fov>
+          <image>
+            <width>320</width>
+            <height>240</height>
+          </image>
+          <clip>
+            <near>0.1</near>
+            <far>100</far>
+          </clip>
+        </camera>
+        <always_on>1</always_on>
+        <update_rate>30</update_rate>
+        <visualize>true</visualize>
+      </sensor>
+    </link>
+  </model>
+</sdf>

--- a/models/openmv_cam/urdf/openmv_cam.xacro
+++ b/models/openmv_cam/urdf/openmv_cam.xacro
@@ -1,0 +1,59 @@
+<?xml version="1.0"?>
+
+<robot name="openmv_cam" xmlns:xacro="http://ros.org/wiki/xacro">
+
+    <xacro:property name="mass" value="0.01" /> <!-- kg -->
+    <xacro:property name="image_height" value="128" />
+    <xacro:property name="horizontal_fov" value="2.007128639793479" />  <!-- 115 deg -->
+    <xacro:property name="vertical_fov" value="1.5009831567151235" /> <!-- 86 deg -->
+    <xacro:property name="image_width" value="${image_height * horizontal_fov / vertical_fov}" />
+    <xacro:property name="namespace" value="" />
+    <xacro:property name="frame_rate" value="10" />
+    <xacro:property name="image_format" value="R8G8B8" />  <!-- L8 -->
+    <xacro:property name="min_distance" value="0.01" />
+    <xacro:property name="max_distance" value="100" />
+    <xacro:property name="enable_visual" value="true" />
+    <xacro:property name="visualize_fov" value="true" />
+    <xacro:property name="enable_collision" value="true" />
+    <xacro:property name="noise_mean" value="0.0" />
+    <xacro:property name="noise_stddev" value="0.0" />
+    <xacro:property name="camera_suffix" value="main" />
+    <xacro:property name="parent_link" value="base_link" />
+
+    <xacro:include filename="openmv_cam_macro.xacro" />
+
+    <link name="base_link"></link>
+
+    <joint name="base_joint" type="fixed">
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <parent link="base_link" />
+      <child link="base_link_inertia" />
+    </joint>
+
+    <link name="base_link_inertia">
+      <inertial>
+        <mass value="${mass}" />
+        <origin xyz="0 0 0" rpy="0 0 0" />
+      </inertial>
+    </link>
+
+    <xacro:openmv_cam_macro
+      namespace="${namespace}"
+      parent_link="${parent_link}"
+      camera_suffix="${camera_suffix}"
+      frame_rate="${frame_rate}"
+      horizontal_fov="${horizontal_fov}"
+      image_width="${image_width}"
+      image_height="${image_height}"
+      image_format="${image_format}"
+      min_distance="${min_distance}"
+      max_distance="${max_distance}"
+      visualize_fov="${visualize_fov}"
+      noise_mean="${noise_mean}"
+      noise_stddev="${noise_stddev}"
+      enable_collision="${enable_collision}"
+      enable_visual="${enable_visual}">
+      <origin xyz="0 0 0" rpy="0 0 0" />
+    </xacro:openmv_cam_macro>
+
+</robot>

--- a/models/openmv_cam/urdf/openmv_cam_macro.xacro
+++ b/models/openmv_cam/urdf/openmv_cam_macro.xacro
@@ -1,0 +1,93 @@
+<?xml version="1.0"?>
+
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
+
+  <xacro:property name="openmv_distortion_k1" value="-0.239734" />
+  <xacro:property name="openmv_distortion_k2" value="0.038031" />
+  <xacro:property name="openmv_distortion_p1" value="-0.000468" />
+  <xacro:property name="openmv_distortion_p2" value="-0.001565" />
+  <xacro:property name="openmv_distortion_k3" value="0" />
+
+  <!-- Macro to add an OpenMV camera. -->
+  <xacro:macro name="openmv_cam_macro"
+    params="namespace parent_link camera_suffix frame_rate
+      horizontal_fov image_width image_height image_format min_distance
+      max_distance noise_mean noise_stddev enable_visual enable_collision visualize_fov *origin">
+    <link name="${namespace}/camera_${camera_suffix}_link">
+      <xacro:if value="${enable_collision}">
+        <collision>
+          <origin xyz="-0.017 0 -0.013" rpy="0 0 0" />
+          <geometry>
+            <!-- <mesh filename="model://openmv_cam/meshes/model.dae" /> -->
+            <box size="0.035 0.035 0.048" />
+          </geometry>
+        </collision>
+      </xacro:if>
+      <xacro:if value="${enable_visual}">
+        <visual>
+          <origin xyz="0 0 0" rpy="0 0 0" />
+          <geometry>
+            <mesh filename="model://openmv_cam/meshes/model.dae" />
+          </geometry>
+        </visual>
+      </xacro:if>
+    </link>
+    <joint name="${namespace}/camera_${camera_suffix}_joint" type="fixed">
+      <xacro:insert_block name="origin" />
+      <parent link="${parent_link}" />
+      <child link="${namespace}/camera_${camera_suffix}_link" />
+    </joint>
+    <gazebo reference="${namespace}/camera_${camera_suffix}_link">
+      <sensor type="camera" name="${namespace}_camera_${camera_suffix}">
+        <xacro:if value="${visualize_fov}">
+          <visualize>true</visualize>
+        </xacro:if>
+        <update_rate>${frame_rate}</update_rate>
+        <camera name="head">
+          <horizontal_fov>${horizontal_fov}</horizontal_fov>
+          <image>
+            <width>${image_width}</width>
+            <height>${image_height}</height>
+            <format>${image_format}</format>
+          </image>
+          <clip>
+            <near>${min_distance}</near>
+            <far>${max_distance}</far>
+          </clip>
+          <noise>
+            <type>gaussian</type>
+            <mean>${noise_mean}</mean>
+            <stddev>${noise_stddev}</stddev>
+          </noise>
+          <distortion>
+            <k1>${openmv_distortion_k1}</k1>
+            <k2>${openmv_distortion_k2}</k2>
+            <p1>${openmv_distortion_p1}</p1>
+            <p2>${openmv_distortion_p2}</p2>
+            <k3>${openmv_distortion_k3}</k3>
+            <center>0.5 0.5</center>
+          </distortion>
+        </camera>
+        <plugin name="${namespace}_camera_${camera_suffix}_controller" filename="libgazebo_ros_camera.so">
+          <robotNamespace>${namespace}</robotNamespace>
+          <alwaysOn>true</alwaysOn>
+          <updateRate>${frame_rate}</updateRate>
+          <cameraName>camera_${camera_suffix}</cameraName>
+          <imageTopicName>image_raw</imageTopicName>
+          <cameraInfoTopicName>camera_info</cameraInfoTopicName>
+          <frameName>camera_${camera_suffix}_link</frameName>
+          <hackBaseline>0.0</hackBaseline>
+          <distortionK1>${openmv_distortion_k1}</distortionK1>
+          <distortionK2>${openmv_distortion_k2}</distortionK2>
+          <distortionT1>${openmv_distortion_p1}</distortionT1>
+          <distortionT2>${openmv_distortion_p2}</distortionT2>
+          <distortionK3>${openmv_distortion_k3}</distortionK3>
+        </plugin>
+      </sensor>
+    </gazebo>
+    <gazebo reference="${namespace}/camera_${camera_suffix}_link">
+      <material>Gazebo/DarkGrey</material>
+    </gazebo>
+  </xacro:macro>
+
+</robot>

--- a/src/openmv_cam_node.py
+++ b/src/openmv_cam_node.py
@@ -17,7 +17,7 @@ class OpenMVCamNode:
         rospy.init_node('openmv_cam_node', argv=sys.argv)
 
         self.device = rospy.get_param('~device', default='/dev/ttyACM0')
-        self.topic = rospy.get_param('~topic', default='openmv_cam/image_raw')
+        self.topic = rospy.get_param('~topic', default='openmv_cam/camera_main/image_raw')
         self.compressed = rospy.get_param('~compressed', default=False)
 
         self.image_type = Image


### PR DESCRIPTION
Add a simple model of the OpenMV Cam for simulation in Gazebo (with support for ROS camera plugins)