### PR TITLE
Feature:  Repository to work with ROS Noetic

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ rosdep install --from-paths /path/to/your/catkin_ws/src --ignore-src
 ```
 
 **Note**:
-For ROS Noetic, since the `camera_info_manager_py` is not available from apt manager, build the [camera_info_manager_py package](https://github.com/ros-perception/camera_info_manager_py) from source
+For ROS Noetic and later, the [`camera_info_manager_py`](https://github.com/ros-perception/camera_info_manager_py) package is not available via `apt-get` and has to be built from source.
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ To resolve the dependencies run:
 rosdep install --from-paths /path/to/your/catkin_ws/src --ignore-src
 ```
 
+**Note**:
+For ROS Noetic, since the `camera_info_manager_py` is not available from apt manager, build the [camera_info_manager_py package](https://github.com/ros-perception/camera_info_manager_py) from source
+
 ## Getting started
 
 Connect the camera and copy the [main.py](util/main.py) file, either using the [OpenMV IDE](https://openmv.io/pages/download) or directly using the mounted storage device.

--- a/src/openmv_cam.py
+++ b/src/openmv_cam.py
@@ -46,7 +46,9 @@ class OpenMVCam:
         """
 
         # Sending 'snap' command causes camera to take snapshot
-        self.port.write('snap')
+        # For python3(Noetic), change the below line to self.port.write('snap'.encode('utf-8'))
+        # For python2, self.port.write('snap')
+        self.port.write('snap'.encode('utf-8'))
         self.port.flush()
 
         # Read 'size' bytes from serial port

--- a/src/openmv_cam.py
+++ b/src/openmv_cam.py
@@ -6,6 +6,7 @@ Source:
 
 import io
 import struct
+import sys
 
 import numpy as np
 import serial
@@ -46,9 +47,11 @@ class OpenMVCam:
         """
 
         # Sending 'snap' command causes camera to take snapshot
-        # For python3(Noetic), change the below line to self.port.write('snap'.encode('utf-8'))
-        # For python2, self.port.write('snap')
-        self.port.write('snap'.encode('utf-8'))
+        # For Python 3 (ROS Noetic and later), encode the 'snap' string as UTF-8
+        snap = 'snap'
+        if sys.version_info[0] >= 3:
+            snap = snap.encode('utf-8')
+        self.port.write(snap)
         self.port.flush()
 
         # Read 'size' bytes from serial port


### PR DESCRIPTION
1. Docs Update: For ROS Noetic, since the `camera_info_manager_py` is not available from apt manager, build the [camera_info_manager_py package](https://github.com/ros-perception/camera_info_manager_py) from source. The [ROS wiki](http://wiki.ros.org/camera_info_manager_py) says it is available only for Melodic
2. Feature: The `snap` command written serially, doesn't work with Python3. So made a small modification of encoding it to `utf-8` which worked.
3. Further, I have tested this with Arduino Nicla Vision.
